### PR TITLE
Solved missing jQuery function

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ import { hubConnection } from 'signalr-shimmy'
 Use just like regular signalR but without $ namespace
 
 ```
-const connection = hubConnection('http://[address]:[port]', options)
+let connection = hubConnection('http://[address]:[port]', options)
+connection.qs = { 'access_token': 'SECRET_TOKEN' };
 const hubProxy = connection.createHubProxy('hubNameString')
 
 // set up event listeners i.e. for incoming "message" event

--- a/build/jQueryShim.js
+++ b/build/jQueryShim.js
@@ -89,7 +89,7 @@ var ajax = function ajax(options) {
 };
 
 function isObject(o) {
-  return null != o && (typeof o === 'undefined' ? 'undefined' : _typeof(o)) === 'object' && Object.prototype.toString.call(o) === '[object Object]';
+  return null != o && (typeof o === 'undefined' ? 'undefined' : typeof(o)) === 'object' && Object.prototype.toString.call(o) === '[object Object]';
 }
 
 var param = function param(data) {

--- a/build/jQueryShim.js
+++ b/build/jQueryShim.js
@@ -88,6 +88,31 @@ var ajax = function ajax(options) {
     };
 };
 
+function isObject(o) {
+  return null != o && (typeof o === 'undefined' ? 'undefined' : _typeof(o)) === 'object' && Object.prototype.toString.call(o) === '[object Object]';
+}
+
+var param = function param(data) {
+  if (!isObject(data)) {
+    return data == null ? "" : data.toString();
+  }
+
+  var buffer = [];
+
+  for (var name in data) {
+    if (!data.hasOwnProperty(name)) {
+      continue;
+    }
+
+    var value = data[name];
+
+    buffer.push(encodeURIComponent(name) + "=" + encodeURIComponent(value == null ? "" : value));
+  }
+
+  var source = buffer.join("&").replace(/%20/g, "+");
+  return source;
+};
+
 module.exports = jQueryDeferred.extend(jqueryFunction, jQueryDeferred, {
     defaultAjaxHeaders: null,
     ajax: ajax,
@@ -103,6 +128,7 @@ module.exports = jQueryDeferred.extend(jqueryFunction, jQueryDeferred, {
     makeArray: function makeArray(arr) {
         return [].slice.call(arr, 0);
     },
+    param: param,
     support: {
         cors: function () {
             var xhrObj = xhr();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalr-shimmy",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "JavaScript SignalR client with jQuery shimmied",
   "keywords": [
     "signalr"

--- a/src/jQueryShim.js
+++ b/src/jQueryShim.js
@@ -82,6 +82,35 @@ const ajax = function (options) {
     };
 };
 
+function isObject(o) {
+  return null != o &&
+    typeof o === 'object' &&
+    Object.prototype.toString.call(o) === '[object Object]';
+}
+
+const param = function (data) {
+    if ( ! isObject( data ) ) {
+      return( ( data == null ) ? "" : data.toString() );
+    }
+
+    let buffer = [];
+
+    for ( let name in data ) {
+      if ( ! data.hasOwnProperty( name ) ) {
+          continue;
+      }
+
+      let value = data[ name ];
+
+      buffer.push(
+          encodeURIComponent( name ) + "=" + encodeURIComponent( ( value == null ) ? "" : value )
+      );
+    }
+
+    const source = buffer.join( "&" ).replace( /%20/g, "+" );
+    return( source );
+}
+
 module.exports = jQueryDeferred.extend(
     jqueryFunction,
     jQueryDeferred,
@@ -92,6 +121,7 @@ module.exports = jQueryDeferred.extend(
         trim: str => str && str.trim(),
         isEmptyObject: obj => !obj || Object.keys(obj).length === 0,
         makeArray: arr => [].slice.call(arr, 0),
+        param: param,
         support: {
             cors: (function () {
                 const xhrObj = xhr();


### PR DESCRIPTION
When using this module I found that if I wanted to add a `qs` when setting up my connection I got the error:
`$.param is not a function` inside my Angular-app. 

I resolved this issue, so now it's possible to add options for the negotiation.